### PR TITLE
MinimalAccount.sol error MiniamlAccount__CallFailed typo

### DIFF
--- a/src/ethereum/MinimalAccount.sol
+++ b/src/ethereum/MinimalAccount.sol
@@ -15,7 +15,7 @@ contract MinimalAccount is IAccount, Ownable {
     //////////////////////////////////////////////////////////////*/
     error MinimalAccount__NotFromEntryPoint();
     error MinimalAccount__NotFromEntryPointOrOwner();
-    error MiniamlAccount__CallFailed(bytes);
+    error MinimalAccount__CallFailed(bytes);
 
     /*//////////////////////////////////////////////////////////////
                             STATE VARIABLES


### PR DESCRIPTION
This pull request corrects a typo in the error declaration. The error `MiniamlAccount__CallFailed(bytes)` has been updated to `MinimalAccount__CallFailed(bytes)`.

**Changes**:
```diff
- error MiniamlAccount__CallFailed(bytes);
+ error MinimalAccount__CallFailed(bytes);
```

**Issue**:
This change addresses and resolves issue #2.