### PR TITLE
typo in MinimalAccount.sol

### DIFF
--- a/src/ethereum/MinimalAccount.sol
+++ b/src/ethereum/MinimalAccount.sol
@@ -54,7 +54,7 @@ contract MinimalAccount is IAccount, Ownable {
     function execute(address dest, uint256 value, bytes calldata functionData) external requireFromEntryPointOrOwner {
         (bool success, bytes memory result) = dest.call{value: value}(functionData);
         if (!success) {
-            revert MinimalAccount__CallFailed(bytes)
+            revert MinimalAccount__CallFailed(result);
         }
     }
 


### PR DESCRIPTION
The revert event must contain a result, not bytes, and the `;` at the end is missing.