### PR TITLE
`Stack Too Deep` Error Re-spawned

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -5,6 +5,7 @@ libs = ["lib"]
 remappings = ['@openzeppelin/contracts=lib/openzeppelin-contracts/contracts']
 is-system = true
 via-ir = true
+optimizer = true
 fs_permissions = [
     { access = "read", path = "./broadcast" },
     { access = "read", path = "./reports" },


### PR DESCRIPTION
While going through [Via Ir](https://updraft.cyfrin.io/courses/advanced-foundry/account-abstraction/via-ir) lesson of Advanced Foundry Course and actually adding `via-ir = true` in my `foundry.toml` as the lesson suggested, I was ready to run my first test of `ZkMinimalAccount.sol` by running the command: `forge test --mt testZkOwnerCanExecuteCommands --zksync`. But, to my surprise, I witnessed a "stack too deep" error right in my terminal:

<img width="1920" height="1080" alt="image_2025-07-26_173429562" src="https://github.com/user-attachments/assets/c535e716-ad10-4f75-9e86-ee89badf9319" />

Initially, I doubted that I must have done something stupid and hence checked my code with this repository back and forth, but found nothing. Then, I decided to clone it, run `forge build`, and test it using the command provided in Makefile: `forge test --zksync --system-mode=true` (making sure `foundryup-zksync` is installed). Well, here's the output...

<img width="1920" height="1080" alt="image_2025-07-26_174255437" src="https://github.com/user-attachments/assets/ffcd1c79-a22d-4f8b-9e9e-59b0442e4221" />

Adding `optimizer = true` in `foundry.toml` fixes it tho

<img width="1920" height="1080" alt="image_2025-07-26_174623319" src="https://github.com/user-attachments/assets/8563d5c4-9cdf-4b25-a6fa-6e70efea374e" />

Additionally, it would be great and definitely advisable if this fix could be included as an update in the lesson itself...only if you find it satisfactory 

Thanks!