### PR TITLE
Bug in SendPackedUserOp.s.sol with nonce update

### DIFF
--- a/script/SendPackedUserOp.s.sol
+++ b/script/SendPackedUserOp.s.sol
@@ -43,7 +43,7 @@ contract SendPackedUserOp is Script {
         address minimalAccount
     ) public view returns (PackedUserOperation memory) {
         // 1. Generate the unsigned data
-        uint256 nonce = vm.getNonce(minimalAccount) - 1;
+        uint256 nonce = IEntryPoint(config.entryPoint).getNonce(minimalAccount, 0);
         PackedUserOperation memory userOp = _generateUnsignedUserOperation(callData, minimalAccount, nonce);
 
         // 2. Get the userOp Hash


### PR DESCRIPTION
In the course repo, SendPackedUserOp.s.sol
When testing on arbitrum sepolia, get revert:
```solidity
function generateSignedUserOperation(
    bytes memory callData,
    HelperConfig.NetworkConfig memory config,
    address minimalAccount
) public view returns (PackedUserOperation memory) {
    // 1. Generate the unsigned data
    uint256 nonce = vm.getNonce(minimalAccount) - 1;
    PackedUserOperation memory userOp = _generateUnsignedUserOperation(callData, minimalAccount, nonce);

    // 2. Get the userOp Hash
    bytes32 userOpHash = IEntryPoint(config.entryPoint).getUserOpHash(userOp);
    bytes32 digest = userOpHash.toEthSignedMessageHash();

    // 3. Sign it
    uint8 v;
    bytes32 r;
    bytes32 s;
    uint256 ANVIL_DEFAULT_KEY = 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80;
    if (block.chainid == 31337) {
        (v, r, s) = vm.sign(ANVIL_DEFAULT_KEY, digest);
    } else {
        (v, r, s) = vm.sign(config.account, digest);
    }
    userOp.signature = abi.encodePacked(r, s, v); // Note the order
    return userOp;
}
```

Using this line uint256 nonce = vm.getNonce(minimalAccount) - 1, will get the wrong nonce.
It is not the minimalAccount nonce for entry point contract, it is the contract's nonce for blockchain.
The entry point contract hold the contract's nonce, we should use that.

So I fix it  :
```solidity
uint256 nonce = IEntryPoint(config.entryPoint).getNonce(minimalAccount, 0);
```

Then I test it on arbitrum seplia, it worked well.