### PR TITLE
fix: added a check for the call in `_payPreFund` and fixed relevant test

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -1,0 +1,17 @@
+{
+  "lib/account-abstraction": {
+    "rev": "7af70c8993a6f42973f520ae0752386a5032abe7"
+  },
+  "lib/forge-std": {
+    "rev": "978ac6fadb62f5f0b723c996f64be52eddba6801"
+  },
+  "lib/foundry-devops": {
+    "rev": "df9f90b490423578142b5dd50752db9427efb2ac"
+  },
+  "lib/foundry-era-contracts": {
+    "rev": "3f99de4a37b126c5cb0466067f37be0c932167b2"
+  },
+  "lib/openzeppelin-contracts": {
+    "rev": "dbb6104ce834628e473d2173bbc9d47f81a9eec3"
+  }
+}

--- a/src/ethereum/MinimalAccount.sol
+++ b/src/ethereum/MinimalAccount.sol
@@ -16,6 +16,7 @@ contract MinimalAccount is IAccount, Ownable {
     error MinimalAccount__NotFromEntryPoint();
     error MinimalAccount__NotFromEntryPointOrOwner();
     error MinimalAccount__CallFailed(bytes);
+    error MinimalAccount__PayPreFundFailed();
 
     /*//////////////////////////////////////////////////////////////
                             STATE VARIABLES
@@ -89,7 +90,9 @@ contract MinimalAccount is IAccount, Ownable {
     function _payPrefund(uint256 missingAccountFunds) internal {
         if (missingAccountFunds != 0) {
             (bool success,) = payable(msg.sender).call{value: missingAccountFunds, gas: type(uint256).max}("");
-            require(success);
+            if (!success) {
+                revert MinimalAccount__PayPreFundFailed();
+            }
         }
     }
 

--- a/src/ethereum/MinimalAccount.sol
+++ b/src/ethereum/MinimalAccount.sol
@@ -89,7 +89,7 @@ contract MinimalAccount is IAccount, Ownable {
     function _payPrefund(uint256 missingAccountFunds) internal {
         if (missingAccountFunds != 0) {
             (bool success,) = payable(msg.sender).call{value: missingAccountFunds, gas: type(uint256).max}("");
-            (success);
+            require(success);
         }
     }
 

--- a/src/zksync/ZkMinimalAccount.sol
+++ b/src/zksync/ZkMinimalAccount.sol
@@ -10,8 +10,9 @@ import {
     Transaction,
     MemoryTransactionHelper
 } from "lib/foundry-era-contracts/src/system-contracts/contracts/libraries/MemoryTransactionHelper.sol";
-import {SystemContractsCaller} from
-    "lib/foundry-era-contracts/src/system-contracts/contracts/libraries/SystemContractsCaller.sol";
+import {
+    SystemContractsCaller
+} from "lib/foundry-era-contracts/src/system-contracts/contracts/libraries/SystemContractsCaller.sol";
 import {
     NONCE_HOLDER_SYSTEM_CONTRACT,
     BOOTLOADER_FORMAL_ADDRESS,
@@ -81,7 +82,13 @@ contract ZkMinimalAccount is IAccount, Ownable {
      * @notice must validate the transaction (check the owner signed the transaction)
      * @notice also check to see if we have enough money in our account
      */
-    function validateTransaction(bytes32, /*_txHash*/ bytes32, /*_suggestedSignedHash*/ Transaction memory _transaction)
+    function validateTransaction(
+        bytes32,
+        /*_txHash*/
+        bytes32,
+        /*_suggestedSignedHash*/
+        Transaction memory _transaction
+    )
         external
         payable
         requireFromBootLoader
@@ -90,7 +97,13 @@ contract ZkMinimalAccount is IAccount, Ownable {
         return _validateTransaction(_transaction);
     }
 
-    function executeTransaction(bytes32, /*_txHash*/ bytes32, /*_suggestedSignedHash*/ Transaction memory _transaction)
+    function executeTransaction(
+        bytes32,
+        /*_txHash*/
+        bytes32,
+        /*_suggestedSignedHash*/
+        Transaction memory _transaction
+    )
         external
         payable
         requireFromBootLoaderOrOwner
@@ -106,7 +119,13 @@ contract ZkMinimalAccount is IAccount, Ownable {
         _executeTransaction(_transaction);
     }
 
-    function payForTransaction(bytes32, /*_txHash*/ bytes32, /*_suggestedSignedHash*/ Transaction memory _transaction)
+    function payForTransaction(
+        bytes32,
+        /*_txHash*/
+        bytes32,
+        /*_suggestedSignedHash*/
+        Transaction memory _transaction
+    )
         external
         payable
     {
@@ -118,8 +137,7 @@ contract ZkMinimalAccount is IAccount, Ownable {
 
     function prepareForPaymaster(bytes32 _txHash, bytes32 _possibleSignedHash, Transaction memory _transaction)
         external
-        payable
-    {}
+        payable {}
 
     /*//////////////////////////////////////////////////////////////
                            INTERNAL FUNCTIONS

--- a/test/ethereum/MinimalAccountTest.t.sol
+++ b/test/ethereum/MinimalAccountTest.t.sol
@@ -99,6 +99,7 @@ contract MinimalAccountTest is Test, ZkSyncChainChecker {
         uint256 missingAccountFunds = 1e18;
 
         // Act
+        vm.deal(address(minimalAccount), 1e18);
         vm.prank(helperConfig.getConfig().entryPoint);
         uint256 validationData = minimalAccount.validateUserOp(packedUserOp, userOperationHash, missingAccountFunds);
         assertEq(validationData, 0);

--- a/test/zksync/ZkMinimalAccountTest.t.sol
+++ b/test/zksync/ZkMinimalAccountTest.t.sol
@@ -11,8 +11,9 @@ import {
     MemoryTransactionHelper
 } from "lib/foundry-era-contracts/src/system-contracts/contracts/libraries/MemoryTransactionHelper.sol";
 import {BOOTLOADER_FORMAL_ADDRESS} from "lib/foundry-era-contracts/src/system-contracts/contracts/Constants.sol";
-import {ACCOUNT_VALIDATION_SUCCESS_MAGIC} from
-    "lib/foundry-era-contracts/src/system-contracts/contracts/interfaces/IAccount.sol";
+import {
+    ACCOUNT_VALIDATION_SUCCESS_MAGIC
+} from "lib/foundry-era-contracts/src/system-contracts/contracts/interfaces/IAccount.sol";
 
 // OZ Imports
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";


### PR DESCRIPTION
-> added the missing check for if the ``call`` is successful or not for ``_payPrefund`` and corrected the relevant test i.e ``testValidationOfUserOps``, that used to have error 
<img width="1257" height="313" alt="Screenshot From 2026-01-17 04-13-48" src="https://github.com/user-attachments/assets/4708148a-2ef6-4ad2-a961-17e425fa057c" />
when the returned boolean from ``call`` was not checked

edit: just noticed, this PR also fixes #7 