### PR TITLE
fix: split CI into separate Ethereum and zkSync test jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,16 +1,17 @@
 name: test
 
-on: workflow_dispatch
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 env:
   FOUNDRY_PROFILE: ci
 
 jobs:
-  check:
-    strategy:
-      fail-fast: true
-
-    name: Foundry project
+  test-ethereum:
+    name: Ethereum Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,10 +26,24 @@ jobs:
       - name: Run Forge build
         run: |
           forge --version
-          forge build --sizes
+          forge build
         id: build
 
-      - name: Run Forge tests
-        run: |
-          forge test -vvv
+      - name: Run Ethereum tests
+        run: forge test --match-path "test/ethereum/**" -vvv
+        id: test
+
+  test-zksync:
+    name: zkSync Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install foundry-zksync
+        uses: dutterbutter/foundry-zksync-toolchain@v1
+
+      - name: Run zkSync tests
+        run: forge test --match-path "test/zksync/**" --zksync --system-mode=true -vvv
         id: test


### PR DESCRIPTION
## Problem
The current workflow uses `foundry-rs/foundry-toolchain` (standard Foundry), 
but this project includes zkSync native AA contracts that require `foundry-zksync`.

This causes two issues:
1. Running `forge test` with standard Foundry throws `unexpected argument '--zksync' found` (exit code 2)
2. Running Ethereum tests under the zkSync toolchain breaks standard EVM 
   cheatcodes like `vm.startBroadcast()` with `Invalid opcode` errors

## Fix
- Split into two separate jobs:
  - **Ethereum Tests** — uses `foundry-rs/foundry-toolchain` (standard Foundry)
  - **zkSync Tests** — uses `dutterbutter/foundry-zksync-toolchain@v1`
- Changed trigger from `workflow_dispatch` to `push/pull_request` so CI 
  runs automatically on every push
- Removed `--sizes` flag to avoid false EIP-170 contract size failures

## How I found this
I was following this course and hit this exact CI failure. It took 17 workflow 
runs to debug. Sharing the fix so others don't face the same issue.